### PR TITLE
Align Space skeleton with Gradio-only deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# 3d-model
+# 3D Model Reconstruction for GIS
+
+This repository documents a complete workflow for turning sparse, non-overlapping photographs into interactive 3D assets that can be hosted on a [Hugging Face Space](https://huggingface.co/spaces). It focuses on pipelines that are appropriate for GIS and urban-planning research, integrating structure-from-motion (SfM), neural rendering (NeRF), and Gaussian Splatting approaches.
+
+## How to use this repository
+
+1. **Study the end-to-end plan** in [`docs/hf_sparse_to_3d_pipeline.md`](docs/hf_sparse_to_3d_pipeline.md). It explains the tooling choices (COLMAP, Nerfstudio, 3D Gaussian Splatting, VGGT depth), provides step-by-step commands, and highlights GIS-specific post-processing.
+2. **Start from the Hugging Face Space skeleton** under [`hf_space/`](hf_space/). The folder contains a production-ready `gradio` application and dependency manifests that you can adapt to your project and deploy directly on Hugging Face without building a Docker image.
+3. **Iterate on the pipeline** by wiring additional reconstruction backends, adding evaluation hooks, or integrating geospatial metadata exports as required by your PhD project.
+
+The repository is intentionally modular so that you can swap in newer research ideas (for example recent CVPR papers) without rewriting the Space front-end.

--- a/docs/hf_sparse_to_3d_pipeline.md
+++ b/docs/hf_sparse_to_3d_pipeline.md
@@ -1,0 +1,317 @@
+# Sparse-Image to 3D Reconstruction Pipeline for Hugging Face Spaces
+
+This guide walks through the full lifecycle required to turn sparse, non-overlapping photographs into a georeferenced 3D asset hosted on a Hugging Face Space. It assumes you are preparing material for GIS-focused urban-planning research and want reproducible steps from dataset assembly to a working web demo.
+
+> **Key idea:** Split the problem into (1) structure-from-motion (SfM) with COLMAP, (2) neural reconstruction with either Nerfstudio (NeRF), 3D Gaussian Splatting, or a hybrid, (3) geospatial post-processing, and (4) packaging the experience into a GPU-backed Space powered by Gradio.
+
+---
+
+## 1. Project goals & success criteria
+
+1. **Robust on sparse imagery:** Inputs may have large baselines and limited overlap, so the pipeline must use reliable feature matching (COLMAP) and optionally auxiliary priors (VGGT depth).
+2. **GIS friendly outputs:** Deliver textured meshes (`.glb`/`.obj`), point clouds (`.ply`/`.las`), and optionally rasterized DSM/DTM layers that can be ingested by QGIS or ArcGIS Pro.
+3. **Interactive Hugging Face demo:** Provide a web UI that accepts images, runs the reconstruction pipeline (either fully on Space hardware or as an orchestrator for offline runs), and previews the result.
+4. **Extensible research harness:** Make it easy to swap in cutting-edge CVPR 2024+ methods (e.g., PointNeRF variants, 3D-R1 for VLM-guided priors) as your PhD evolves.
+
+---
+
+## 2. Core toolkit overview
+
+| Stage | Recommended tooling | Why it matters |
+| --- | --- | --- |
+| Image calibration & SfM | [COLMAP](https://github.com/colmap/colmap) | De facto standard for camera pose estimation and sparse/dense reconstruction. |
+| Depth priors | [VGGT / PointMap](https://vgg-t.github.io/) | Helps regularize sparse scenes by providing depth & normal predictions that COLMAP can fuse. |
+| Neural rendering | [Nerfstudio](https://docs.nerf.studio/quickstart/installation.html) with `instant-ngp` or `nerfacto` configs | Streamlined training scripts, evaluation, and export to mesh/point clouds. |
+| Fast point-based models | [3D Gaussian Splatting (Inria)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/) | Faster convergence than NeRF, works well with limited views when initialized from COLMAP cameras. |
+| Indoor-specific | [Fast3R (Meta)](https://github.com/facebookresearch/fast3r) | Handles Manhattan-world indoor scenes if you target building interiors. |
+| Language priors | [3D-R1](https://github.com/AIGeeksGroup/3D-R1) | Use if you want to integrate VLM guidance or textual semantics. |
+
+Feel free to incorporate other CVPR 2023/2024 papers—this pipeline is modular.
+
+---
+
+## 3. Local development environment
+
+1. **Hardware**: CUDA-capable GPU (>=12 GB VRAM recommended). CPU-only runs are possible for COLMAP but neural training will be slow.
+2. **System packages** (Ubuntu 22.04 example):
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential cmake git wget ninja-build \
+       libboost-all-dev libeigen3-dev libfreeimage-dev libmetis-dev \
+       libgoogle-glog-dev libgflags-dev libglew-dev qtbase5-dev
+   ```
+3. **Python environment**:
+   ```bash
+   conda create -n hf-3d python=3.10
+   conda activate hf-3d
+   pip install --upgrade pip
+   ```
+4. **Install COLMAP** (choose one):
+   - Build from source following the [official instructions](https://colmap.github.io/install.html).
+   - Or `conda install -c conda-forge colmap` if using Conda-forge packages.
+5. **Install Nerfstudio**:
+   ```bash
+   pip install nerfstudio
+   ns-install-cli
+   ```
+6. **Install 3D Gaussian Splatting** (requires CUDA build):
+   ```bash
+   git clone https://github.com/graphdeco-inria/gaussian-splatting.git
+   cd gaussian-splatting
+   pip install -r requirements.txt
+   python setup.py build_ext --inplace
+   ```
+7. **Optional: VGGT depth & PointMap**:
+   ```bash
+   git clone https://github.com/nianticlabs/pointmap.git
+   cd pointmap
+   pip install -r requirements.txt
+   ```
+8. **Validate** by running small demo datasets provided by Nerfstudio (`ns-download-data --dataset nerfstudio --capture nerfstudio --output-dir data/nerfstudio`).
+
+> Tip: Use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [mamba](https://mamba.readthedocs.io/) to isolate dependencies between COLMAP, Nerfstudio, and the Gaussian Splatting CUDA extensions.
+
+---
+
+## 4. Data preparation workflow
+
+1. **Collect imagery**
+   - Capture JPEG/PNG photos with consistent exposure where possible.
+   - Record GPS/IMU metadata if available (smartphone EXIF is fine). Store these in a CSV for later georeferencing.
+   - For aerial photogrammetry, maintain at least ~60% forward overlap even if lateral overlap is low.
+2. **Organize dataset**
+   ```text
+   dataset/
+     images/
+       img_0001.jpg
+       img_0002.jpg
+     meta.csv            # optional per-image metadata
+   ```
+3. **Run COLMAP SfM** (automatic reconstruction):
+   ```bash
+   mkdir -p outputs/colmap
+   colmap feature_extractor \
+       --database_path outputs/colmap/database.db \
+       --image_path dataset/images \
+       --SiftExtraction.use_gpu 1
+
+   colmap exhaustive_matcher \
+       --database_path outputs/colmap/database.db \
+       --SiftMatching.use_gpu 1
+
+   colmap mapper \
+       --database_path outputs/colmap/database.db \
+       --image_path dataset/images \
+       --output_path outputs/colmap/sparse
+
+   colmap image_undistorter \
+       --image_path dataset/images \
+       --input_path outputs/colmap/sparse/0 \
+       --output_path outputs/colmap/dense \
+       --output_type COLMAP
+   ```
+4. **Depth fusion (optional but recommended)**
+   - Use VGGT to predict per-image depth maps:
+     ```bash
+     python tools/infer_vggt_depth.py \
+         --images dataset/images \
+         --output outputs/vggt/depths
+     ```
+   - Fuse VGGT priors in COLMAP's dense reconstruction:
+     ```bash
+     colmap patch_match_stereo \
+         --workspace_path outputs/colmap/dense \
+         --PatchMatchStereo.geom_consistency true \
+         --PatchMatchStereo.depth_prior_path outputs/vggt/depths
+
+     colmap stereo_fusion \
+         --workspace_path outputs/colmap/dense \
+         --output_path outputs/colmap/fused.ply
+     ```
+5. **Inspect coverage** using `colmap gui` or Meshlab. Re-capture imagery if coverage gaps exist.
+6. **Export camera poses** for downstream models:
+   ```bash
+   colmap model_converter \
+       --input_path outputs/colmap/sparse/0 \
+       --output_path outputs/nerfstudio \
+       --output_type NERFSTUDIO
+   ```
+
+---
+
+## 5. Neural reconstruction backends
+
+### 5.1 Nerfstudio (NeRF)
+1. **Prepare Nerfstudio dataset**:
+   ```bash
+   ns-process-data images --data data/dataset --output-dir data/nerfstudio-dataset
+   ```
+2. **Train** (choose configuration based on sparsity):
+   ```bash
+   ns-train nerfacto \
+       --data data/nerfstudio-dataset \
+       --pipeline.model.depth-importance 0.3 \
+       --pipeline.datamanager.camera-optimizer.mode off
+   ```
+   - Use `--pipeline.model.background-color random` to improve robustness for outdoor imagery.
+   - For extremely sparse captures, try `ns-train splatfacto` which mixes point splatting with NeRF.
+3. **Evaluate**:
+   ```bash
+   ns-eval --load-config outputs/nerfacto/2024-xx-xx/config.yml
+   ```
+4. **Export**:
+   ```bash
+   ns-export poisson \
+       --load-config outputs/nerfacto/2024-xx-xx/config.yml \
+       --output-path exports/mesh
+
+   ns-export gaussian-splat \
+       --load-config outputs/nerfacto/2024-xx-xx/config.yml \
+       --output-path exports/gaussians
+   ```
+
+### 5.2 3D Gaussian Splatting
+1. **Convert COLMAP cameras** to the expected format:
+   ```bash
+   python convert.py -s outputs/colmap/dense -o data/gaussian
+   ```
+   (Use the conversion script provided in the Gaussian Splatting repository.)
+2. **Train / optimize**:
+   ```bash
+   python train.py \
+       -s data/gaussian \
+       -m outputs/gaussian \
+       --iterations 7000 \
+       --resolution 2
+   ```
+3. **Export** Gaussian cloud as `.ply` or `.splat` and convert to mesh with [Gaussian Surfels](https://github.com/antimatter15/splat) if a watertight surface is needed.
+
+### 5.3 Hybrid or alternative models
+- **Fast3R**: Useful for structured indoor scans; follow repo instructions and feed COLMAP poses.
+- **3D-R1**: Combine textual prompts (e.g., building materials) with geometry to hallucinate missing views.
+- **Recent CVPR papers**: Keep a `research/notes.md` log and plug new methods as additional backends in the Space (see Section 8.4).
+
+---
+
+## 6. Post-processing & GIS integration
+
+1. **Scale & georeference**
+   - Align the reconstructed model with ground control points (GCPs) using tools like [OpenSfM GeoAligner](https://github.com/mapillary/OpenSfM) or `pytransform3d`.
+   - Convert from local COLMAP coordinates to EPSG codes relevant to your study area using `pyproj`.
+2. **Clean geometry**
+   - Use [Meshlab](https://www.meshlab.net/) or [Blender](https://www.blender.org/) for decimation, hole filling, and texturing.
+   - Export `glb` for real-time viewers and `las`/`laz` for point clouds.
+3. **Generate rasters**
+   - Rasterize point clouds with PDAL to produce DSM/DTM/NDVI layers:
+     ```bash
+     pdal pipeline pipelines/dsm.json
+     ```
+4. **Metadata packaging**
+   - Create a `metadata.json` storing CRS, scale, original photo IDs, and licensing info for reproducibility.
+
+---
+
+## 7. Hugging Face Space deployment plan
+
+### 7.1 Repository layout
+```
+.
+├── hf_space/
+│   ├── app.py              # Gradio UI + orchestration logic
+│   ├── requirements.txt    # Python dependencies installed by the Space runtime
+│   ├── packages.txt        # apt packages needed for COLMAP and OpenGL support
+│   ├── README.md           # Usage instructions shown on Space page
+│   ├── assets/
+│   │   └── demo.zip        # (Optional) sample dataset for smoke testing
+│   └── external/
+│       └── gaussian-splatting/   # (Optional) clone of the upstream repository
+└── docs/
+    └── ...
+```
+
+### 7.2 Space hardware & settings
+- **Hardware**: Request at least an `A10G` or `A100` GPU Space. COLMAP + Nerfstudio benefit from >12 GB VRAM.
+- **Runtime**: Stick with the default **Gradio** Space SDK. Dependencies install automatically from `requirements.txt`, while `packages.txt` pulls in the system-level libraries COLMAP needs (OpenGL, Eigen, Boost, etc.).
+- **External repositories**: If you plan to expose the Gaussian Splatting backend, clone the upstream repository into `hf_space/external/gaussian-splatting` or set the `GAUSSIAN_SPLATTING_ROOT` environment variable so the app can find it at runtime.
+- **Persistent storage**: Enable the `Persistent storage` option so trained models and cached COLMAP databases survive restarts.
+- **Secrets**: Store API keys (if any) using the Space Secrets feature. Not strictly needed unless you access private datasets.
+
+### 7.3 CI / precompute strategy
+- Running the entire pipeline on every user upload may be too slow. Two deployment options:
+  1. **Interactive preview (recommended)**: Run COLMAP + Gaussian Splatting on a subset of uploaded images (or downscaled versions) directly in the Space, returning a low-res preview + instructions to download a zipped workspace for offline refinement.
+  2. **Asynchronous jobs**: Use [Spaces Webhooks](https://huggingface.co/docs/hub/spaces-webhooks) to forward uploads to a private GPU server, then notify the user via email/slack when high-quality outputs are ready.
+
+### 7.4 Integrating new backends
+- The `ReconstructionRunner` class in `hf_space/app.py` exposes a `register_backend` method. Plug any new CVPR models by providing a callable that accepts the workspace path and returns the exported artifact.
+- Keep each backend self-contained (install requirements, compile CUDA extensions) to avoid runtime conflicts.
+
+---
+
+## 8. Running the Hugging Face Space locally
+
+1. **Clone this repository** and enter `hf_space/`.
+2. **Create a virtual environment** (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. **Install prerequisites**:
+   ```bash
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+   If you intend to exercise the Gaussian Splatting path, clone its repository so the app can access it:
+   ```bash
+   git clone https://github.com/graphdeco-inria/gaussian-splatting.git external/gaussian-splatting
+   ```
+4. **Launch the Gradio app**:
+   ```bash
+   python app.py
+   ```
+   By default, the interface listens on `http://127.0.0.1:7860`. Set `HF3D_OUTPUT_ROOT=/path/to/runs` to control where intermediate artifacts are written, and `GAUSSIAN_SPLATTING_ROOT` if you cloned the repository elsewhere.
+5. **Upload test images** (drag & drop zipped images or use the sample asset).
+6. **Push to Hugging Face**:
+   ```bash
+   huggingface-cli login
+   huggingface-cli repo create username/urban-3d-space --type space --sdk gradio
+   git remote add space https://huggingface.co/spaces/username/urban-3d-space
+   git push space main
+   ```
+7. **Monitor** the build logs on the Space page and resolve missing dependencies if necessary.
+
+---
+
+## 9. Operational checklist
+
+- [ ] Validate dataset ingestion on at least two capture types (street-level photos and UAV imagery).
+- [ ] Benchmark inference time for Nerfstudio vs Gaussian Splatting on your Space hardware.
+- [ ] Enable persistent storage and test restart resilience.
+- [ ] Document CRS conversions and maintain a changelog for your advisor.
+- [ ] Set up automated smoke tests (e.g., run COLMAP on a 3-image sample) using GitHub Actions or Spaces CI.
+
+---
+
+## 10. Further reading & research leads
+
+- CVPR 2024 highlights: check `HoloDiffusion`, `LGM`, `Street Gaussians` for urban-scale reconstructions.
+- Explore `sat2pc` or `CityNeRF` papers if you plan to merge satellite imagery with ground photos.
+- For GIS integration, read the [OGC 3D Tiles specification](https://www.ogc.org/standard/3dtiles/) and consider exporting to Cesium for web-based city planning demos.
+- Keep track of [Nerfstudio releases](https://github.com/nerfstudio-project/nerfstudio/releases) for new training configs tailored to sparse captures.
+
+---
+
+## 11. Support matrix
+
+| Component | Tested locally | Runs on Hugging Face GPU Space | Notes |
+| --- | --- | --- | --- |
+| COLMAP SfM | ✅ | ✅ (via `packages.txt`) | Requires OpenGL runtime; ensure the Space hardware supports CUDA acceleration. |
+| Nerfstudio (nerfacto) | ✅ | ✅ | Install via pip; set `--max-num-iterations` to cap runtime on shared hardware. |
+| 3D Gaussian Splatting | ✅ | ⚠️ | CUDA extensions compile during build; may need to pre-build wheels to reduce Space build time. |
+| VGGT depth | ⚠️ | ⚠️ | Heavy ViT models; download checkpoints during build and store in persistent volume. |
+| Fast3R | ⚠️ | ⚠️ | Useful only for indoor scenes; optional. |
+
+Legend: ✅ = recommended, ⚠️ = optional/experimental, ❌ = not supported.
+
+---
+
+By following this guide and adapting the sample Space in this repository, you can deliver a production-quality 3D reconstruction demo for your GIS-oriented PhD application while leaving room to incorporate the latest research ideas.

--- a/hf_space/README.md
+++ b/hf_space/README.md
@@ -1,0 +1,39 @@
+# Hugging Face Space Skeleton
+
+This folder contains a reference implementation of a Hugging Face Space that turns a bundle of sparse photographs into a previewable 3D reconstruction. It assumes the heavy lifting is performed by COLMAP, Nerfstudio, and 3D Gaussian Splatting.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `app.py` | Gradio application that orchestrates preprocessing, reconstruction backends, and artifact export. |
+| `requirements.txt` | Python dependencies installed by the Space runtime. |
+| `packages.txt` | `apt` packages Hugging Face installs before pip dependencies (COLMAP prerequisites). |
+| `assets/demo.zip` | Drop a miniature dataset here for automated smoke tests (optional). |
+| `external/gaussian-splatting/` | (Optional) place the upstream Gaussian Splatting repo here if you want to expose that backend. |
+
+## Running locally
+
+```bash
+python -m venv .venv               # optional but recommended
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Optional: only if you want Gaussian Splatting available
+git clone https://github.com/graphdeco-inria/gaussian-splatting.git external/gaussian-splatting
+
+# Launch the interface
+python app.py
+```
+
+Open http://localhost:7860 to access the Gradio UI. Override `HF3D_OUTPUT_ROOT` to choose where run artifacts are stored and `GAUSSIAN_SPLATTING_ROOT` if the repository lives somewhere else on disk.
+
+## Deploying to Hugging Face Spaces
+
+1. Create a new Space with the **Gradio** SDK and GPU hardware.
+2. Upload the contents of this folder to the Space repository (or set it as a Git submodule).
+3. If you modify dependencies, rebuild the Space and monitor logs for compilation errors (Gaussian Splatting requires CUDA).
+4. Enable persistent storage to cache COLMAP databases, Gaussian point clouds, and Nerfstudio checkpoints.
+
+See the root documentation for more context and pipeline details.

--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+import os
+import shutil
+import subprocess
+import textwrap
+import uuid
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+import gradio as gr
+from PIL import Image
+
+
+def _run_command(command: List[str], cwd: Optional[Path] = None, env: Optional[Dict[str, str]] = None) -> Tuple[int, str]:
+    """Execute a shell command and capture combined stdout/stderr."""
+    process = subprocess.run(
+        command,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return process.returncode, process.stdout
+
+
+@dataclass
+class Backend:
+    name: str
+    description: str
+    runner: Callable[[Path, Path, Optional[Dict[str, Path]], int], Tuple[Path, List[str]]]
+
+
+class ReconstructionRunner:
+    """Coordinate preprocessing, COLMAP, and neural backends."""
+
+    def __init__(self, output_root: Optional[Path] = None) -> None:
+        root = output_root or Path(os.environ.get("HF3D_OUTPUT_ROOT", "/tmp/hf_3d_runs"))
+        root.mkdir(parents=True, exist_ok=True)
+        self.output_root = root
+        self.backends: Dict[str, Backend] = {}
+        self._register_default_backends()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def available_methods(self) -> List[str]:
+        return list(self.backends.keys())
+
+    def describe_backend(self, name: str) -> str:
+        backend = self.backends.get(name)
+        return backend.description if backend else ""
+
+    def run(
+        self,
+        uploads: Iterable[Any],
+        method: str,
+        max_resolution: int,
+        skip_colmap: bool,
+    ) -> Tuple[str, Optional[Path]]:
+        logs: List[str] = []
+        timestamp = dt.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        workspace = self.output_root / f"run_{timestamp}_{uuid.uuid4().hex[:8]}"
+        dataset_root = workspace / "dataset"
+        images_dir = dataset_root / "images"
+        images_dir.mkdir(parents=True, exist_ok=True)
+        logs.append(f"Workspace initialized at {workspace}")
+
+        try:
+            ingest_count = self._ingest_uploads(uploads, images_dir, max_resolution)
+        except Exception as exc:  # noqa: BLE001 - top-level guard for user feedback
+            logs.append(f"[ERROR] Failed to ingest inputs: {exc}")
+            return "\n".join(logs), None
+
+        if ingest_count == 0:
+            logs.append("[ERROR] No images detected in upload. Provide JPG/PNG files or a ZIP archive.")
+            return "\n".join(logs), None
+
+        logs.append(f"Ingested {ingest_count} image(s). Max resolution capped at {max_resolution}px")
+
+        colmap_outputs: Optional[Dict[str, Path]] = None
+        if skip_colmap:
+            logs.append("Skipping COLMAP as requested. Downstream models must rely on precomputed poses.")
+        else:
+            try:
+                colmap_outputs, colmap_logs = self._run_colmap(images_dir, workspace / "colmap", max_resolution)
+                logs.extend(colmap_logs)
+            except FileNotFoundError as exc:
+                logs.append(
+                    textwrap.dedent(
+                        f"""
+                        [ERROR] Required binary `{exc}` was not found. Ensure COLMAP is installed or set
+                        `skip_colmap=True` if you plan to upload precomputed camera poses.
+                        """
+                    ).strip()
+                )
+                return "\n".join(logs), None
+            except RuntimeError as exc:
+                logs.append(str(exc))
+                return "\n".join(logs), None
+
+        backend = self.backends.get(method)
+        if not backend:
+            logs.append(f"[ERROR] Unknown backend '{method}'. Available options: {', '.join(self.available_methods())}")
+            return "\n".join(logs), None
+
+        try:
+            artifact_path, backend_logs = backend.runner(workspace, dataset_root, colmap_outputs, max_resolution)
+            logs.extend(backend_logs)
+        except Exception as exc:  # noqa: BLE001 - propagate details to UI
+            logs.append(f"[ERROR] Backend '{method}' failed: {exc}")
+            return "\n".join(logs), None
+
+        logs.append(f"Artifacts packaged at {artifact_path}")
+        return "\n".join(logs), artifact_path
+
+    # ------------------------------------------------------------------
+    # Backend registration
+    # ------------------------------------------------------------------
+    def register_backend(self, backend: Backend) -> None:
+        self.backends[backend.name] = backend
+
+    def _register_default_backends(self) -> None:
+        self.register_backend(
+            Backend(
+                name="Nerfstudio (NeRF)",
+                description=(
+                    "Optimizes a NeRF with the nerfacto recipe, exports a Poisson surface mesh, and packs all outputs "
+                    "(config, checkpoints, mesh, transforms.json) into a ZIP archive."
+                ),
+                runner=self._run_nerfstudio,
+            )
+        )
+        self.register_backend(
+            Backend(
+                name="3D Gaussian Splatting",
+                description=(
+                    "Uses the Inria Gaussian Splatting reference implementation initialized from COLMAP cameras. "
+                    "Returns the optimized Gaussian point cloud and training logs."
+                ),
+                runner=self._run_gaussian_splatting,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Input ingestion helpers
+    # ------------------------------------------------------------------
+    def _ingest_uploads(self, uploads: Iterable[Any], images_dir: Path, max_resolution: int) -> int:
+        metadata: List[Dict[str, object]] = []
+        count = 0
+        for item in uploads:
+            if not item:
+                continue
+            src_path = Path(getattr(item, "name", getattr(item, "path", "")))
+            if not src_path.exists():
+                # Gradio may store temp files in `.name`; fallback to `.path` when available
+                if hasattr(item, "path"):
+                    src_path = Path(item.path)
+            if not src_path.exists():
+                continue
+
+            if zipfile.is_zipfile(src_path):
+                with zipfile.ZipFile(src_path, "r") as archive:
+                    for member in archive.namelist():
+                        lower = member.lower()
+                        if lower.endswith((".jpg", ".jpeg", ".png")):
+                            data = archive.read(member)
+                            image = Image.open(io.BytesIO(data))
+                            dest = images_dir / Path(member).name
+                            self._save_image(image, dest, max_resolution)
+                            metadata.append(self._image_metadata(dest, source=str(member)))
+                            count += 1
+            else:
+                image = Image.open(src_path)
+                dest = images_dir / src_path.name
+                self._save_image(image, dest, max_resolution)
+                metadata.append(self._image_metadata(dest, source=str(src_path.name)))
+                count += 1
+
+        if metadata:
+            dataset_meta = {
+                "created_at": dt.datetime.utcnow().isoformat() + "Z",
+                "max_resolution": max_resolution,
+                "images": metadata,
+            }
+            meta_path = images_dir.parent / "metadata.json"
+            meta_path.write_text(json.dumps(dataset_meta, indent=2))
+        return count
+
+    @staticmethod
+    def _save_image(image: Image.Image, destination: Path, max_resolution: int) -> None:
+        image = image.convert("RGB")
+        width, height = image.size
+        scale = min(1.0, max_resolution / max(width, height))
+        if scale < 1.0:
+            new_size = (int(width * scale), int(height * scale))
+            image = image.resize(new_size, Image.LANCZOS)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        image.save(destination, quality=95)
+
+    @staticmethod
+    def _image_metadata(path: Path, source: str) -> Dict[str, object]:
+        with Image.open(path) as image:
+            width, height = image.size
+        return {
+            "filename": path.name,
+            "width": width,
+            "height": height,
+            "source": source,
+        }
+
+    # ------------------------------------------------------------------
+    # COLMAP integration
+    # ------------------------------------------------------------------
+    def _run_colmap(self, images_dir: Path, output_dir: Path, max_resolution: int) -> Tuple[Dict[str, Path], List[str]]:
+        if shutil.which("colmap") is None:
+            raise FileNotFoundError("colmap")
+
+        logs: List[str] = ["Running COLMAP reconstruction…"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        database_path = output_dir / "database.db"
+        sparse_dir = output_dir / "sparse"
+        dense_dir = output_dir / "dense"
+        sparse_dir.mkdir(exist_ok=True)
+
+        commands = [
+            (
+                "Feature extraction",
+                [
+                    "colmap",
+                    "feature_extractor",
+                    "--database_path",
+                    str(database_path),
+                    "--image_path",
+                    str(images_dir),
+                    "--SiftExtraction.use_gpu",
+                    "1",
+                    "--SiftExtraction.max_image_size",
+                    str(max_resolution),
+                ],
+            ),
+            (
+                "Exhaustive matcher",
+                [
+                    "colmap",
+                    "exhaustive_matcher",
+                    "--database_path",
+                    str(database_path),
+                    "--SiftMatching.use_gpu",
+                    "1",
+                ],
+            ),
+            (
+                "Mapper",
+                [
+                    "colmap",
+                    "mapper",
+                    "--database_path",
+                    str(database_path),
+                    "--image_path",
+                    str(images_dir),
+                    "--output_path",
+                    str(sparse_dir),
+                ],
+            ),
+            (
+                "Image undistorter",
+                [
+                    "colmap",
+                    "image_undistorter",
+                    "--image_path",
+                    str(images_dir),
+                    "--input_path",
+                    str(sparse_dir / "0"),
+                    "--output_path",
+                    str(dense_dir),
+                    "--output_type",
+                    "COLMAP",
+                ],
+            ),
+        ]
+
+        for stage, command in commands:
+            logs.append(f"\n$ {' '.join(command)}")
+            code, output = _run_command(command)
+            logs.append(output)
+            if code != 0:
+                raise RuntimeError(f"[ERROR] COLMAP stage '{stage}' failed with exit code {code}.")
+
+        outputs = {
+            "database": database_path,
+            "sparse": sparse_dir / "0",
+            "dense": dense_dir,
+        }
+        logs.append("COLMAP completed successfully.")
+        return outputs, logs
+
+    # ------------------------------------------------------------------
+    # Backend implementations
+    # ------------------------------------------------------------------
+    def _run_nerfstudio(
+        self,
+        workspace: Path,
+        dataset_root: Path,
+        colmap_outputs: Optional[Dict[str, Path]],
+        max_resolution: int,
+    ) -> Tuple[Path, List[str]]:
+        if shutil.which("ns-train") is None:
+            raise FileNotFoundError("ns-train")
+
+        logs: List[str] = ["Launching Nerfstudio pipeline…"]
+        processed_dir = workspace / "nerfstudio" / "processed"
+        runs_dir = workspace / "nerfstudio" / "runs"
+        export_dir = workspace / "nerfstudio" / "export"
+        processed_dir.mkdir(parents=True, exist_ok=True)
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        export_dir.mkdir(parents=True, exist_ok=True)
+
+        data_source = dataset_root / "images"
+        process_cmd = [
+            "ns-process-data",
+            "images",
+            "--data",
+            str(data_source),
+            "--output-dir",
+            str(processed_dir),
+            "--max-num-downscales",
+            str(max(1, int(max_resolution / 512))),
+        ]
+        if colmap_outputs:
+            process_cmd.extend(["--skip-colmap"])
+            process_cmd.extend(["--colmap-model-path", str(colmap_outputs["sparse"])])
+
+        logs.append(f"\n$ {' '.join(process_cmd)}")
+        code, output = _run_command(process_cmd)
+        logs.append(output)
+        if code != 0:
+            raise RuntimeError("ns-process-data failed. See logs above.")
+
+        train_cmd = [
+            "ns-train",
+            "nerfacto",
+            "--data",
+            str(processed_dir),
+            "--max-num-iterations",
+            "3000",
+            "--output-dir",
+            str(runs_dir),
+            "--viewer.quit-on-train-completion",
+            "True",
+            "--pipeline.model.depth-importance",
+            "0.3",
+        ]
+        logs.append(f"\n$ {' '.join(train_cmd)}")
+        code, output = _run_command(train_cmd)
+        logs.append(output)
+        if code != 0:
+            raise RuntimeError("ns-train failed. Consider reducing iterations or verifying GPU availability.")
+
+        configs = sorted(runs_dir.rglob("config.yml"))
+        if not configs:
+            raise RuntimeError("Unable to locate Nerfstudio config.yml after training.")
+        config_path = configs[-1]
+
+        export_cmd = [
+            "ns-export",
+            "poisson",
+            "--load-config",
+            str(config_path),
+            "--output-path",
+            str(export_dir),
+        ]
+        logs.append(f"\n$ {' '.join(export_cmd)}")
+        code, output = _run_command(export_cmd)
+        logs.append(output)
+        if code != 0:
+            raise RuntimeError("ns-export failed. Check above logs for details.")
+
+        mesh_path = export_dir / "mesh.obj"
+        artifact_path = workspace / "nerfstudio_result.zip"
+        with zipfile.ZipFile(artifact_path, "w") as archive:
+            for path in [mesh_path, export_dir / "mesh.mtl", config_path, processed_dir / "transforms.json"]:
+                if path.exists():
+                    archive.write(path, arcname=path.relative_to(workspace))
+            for ckpt in runs_dir.rglob("*.ckpt"):
+                archive.write(ckpt, arcname=ckpt.relative_to(workspace))
+        logs.append("Nerfstudio export complete.")
+        return artifact_path, logs
+
+    def _run_gaussian_splatting(
+        self,
+        workspace: Path,
+        dataset_root: Path,
+        colmap_outputs: Optional[Dict[str, Path]],
+        max_resolution: int,
+    ) -> Tuple[Path, List[str]]:
+        default_repo = Path(__file__).resolve().parent / "external" / "gaussian-splatting"
+        repo_root = Path(os.environ.get("GAUSSIAN_SPLATTING_ROOT", default_repo))
+        convert_script = repo_root / "convert.py"
+        train_script = repo_root / "train.py"
+        if not convert_script.exists() or not train_script.exists():
+            raise FileNotFoundError(
+                "Gaussian Splatting repository not found. Clone it to 'external/gaussian-splatting' "
+                "or set GAUSSIAN_SPLATTING_ROOT to point at the upstream project."
+            )
+        if not colmap_outputs:
+            raise RuntimeError("Gaussian Splatting requires COLMAP outputs. Disable 'Skip COLMAP'.")
+
+        logs: List[str] = ["Launching 3D Gaussian Splatting pipeline…"]
+        gaussian_root = workspace / "gaussian"
+        data_dir = gaussian_root / "data"
+        model_dir = gaussian_root / "model"
+        gaussian_root.mkdir(parents=True, exist_ok=True)
+
+        convert_cmd = [
+            "python3",
+            str(convert_script),
+            "-s",
+            str(colmap_outputs["dense"]),
+            "-o",
+            str(data_dir),
+        ]
+        logs.append(f"\n$ {' '.join(convert_cmd)}")
+        code, output = _run_command(convert_cmd, cwd=repo_root)
+        logs.append(output)
+        if code != 0:
+            raise RuntimeError("Gaussian Splatting conversion failed. Verify COLMAP dense output.")
+
+        train_cmd = [
+            "python3",
+            str(train_script),
+            "-s",
+            str(data_dir),
+            "-m",
+            str(model_dir),
+            "--iterations",
+            "7000",
+            "--resolution",
+            str(max(1, max_resolution // 512)),
+        ]
+        logs.append(f"\n$ {' '.join(train_cmd)}")
+        code, output = _run_command(train_cmd, cwd=repo_root)
+        logs.append(output)
+        if code != 0:
+            raise RuntimeError("Gaussian Splatting training failed. See logs for CUDA-related messages.")
+
+        ply_candidates = sorted(model_dir.rglob("*.ply"))
+        if not ply_candidates:
+            raise RuntimeError("No PLY point cloud found after Gaussian Splatting training.")
+        ply_path = ply_candidates[-1]
+
+        artifact_path = workspace / "gaussian_result.zip"
+        with zipfile.ZipFile(artifact_path, "w") as archive:
+            archive.write(ply_path, arcname=ply_path.relative_to(workspace))
+            for log_file in gaussian_root.rglob("*.log"):
+                archive.write(log_file, arcname=log_file.relative_to(workspace))
+        logs.append("Gaussian Splatting export complete.")
+        return artifact_path, logs
+
+
+# ----------------------------------------------------------------------
+# Gradio interface
+# ----------------------------------------------------------------------
+
+def build_interface() -> gr.Blocks:
+    output_override = os.environ.get("HF3D_OUTPUT_ROOT")
+    if output_override:
+        output_root = Path(output_override)
+    else:
+        output_root = Path(__file__).resolve().parent / "runs"
+    runner = ReconstructionRunner(output_root=output_root)
+
+    with gr.Blocks(title="Sparse Images to 3D Reconstruction") as demo:
+        gr.Markdown(
+            textwrap.dedent(
+                """
+                # Sparse Images ➜ 3D Reconstruction
+
+                Upload a folder or ZIP archive of sparse, non-overlapping photographs. The app will run COLMAP to estimate camera
+                poses, then optimize either a Nerfstudio NeRF or a 3D Gaussian Splatting model and return a downloadable artifact.
+                Expect several minutes of processing time for high-resolution captures.
+                """
+            )
+        )
+
+        with gr.Row():
+            uploads = gr.Files(label="Images or ZIP archive", file_types=["image", ".zip"], file_count="multiple")
+            method = gr.Dropdown(
+                choices=runner.available_methods(),
+                value="Nerfstudio (NeRF)",
+                label="Reconstruction backend",
+            )
+
+        with gr.Row():
+            max_resolution = gr.Slider(
+                minimum=512,
+                maximum=4096,
+                step=256,
+                value=2048,
+                label="Max processing resolution (pixels)",
+            )
+            skip_colmap = gr.Checkbox(
+                value=False,
+                label="Skip COLMAP (use existing poses)",
+            )
+
+        default_backend = runner.available_methods()[0] if runner.available_methods() else ""
+        backend_description = gr.Markdown(runner.describe_backend(default_backend))
+        method.change(
+            fn=lambda choice: runner.describe_backend(choice),
+            inputs=method,
+            outputs=backend_description,
+        )
+        run_button = gr.Button("Start reconstruction", variant="primary")
+
+        logs = gr.Textbox(label="Pipeline log", lines=20)
+        artifact = gr.File(label="Download results")
+
+        def _execute(files: List[Any], backend: str, resolution: int, skip: bool) -> Tuple[str, Optional[str]]:
+            log_text, artifact_path = runner.run(files, backend, resolution, skip)
+            if artifact_path is None:
+                return log_text, None
+            return log_text, str(artifact_path)
+
+        run_button.click(
+            fn=_execute,
+            inputs=[uploads, method, max_resolution, skip_colmap],
+            outputs=[logs, artifact],
+        )
+
+    return demo
+
+
+def main() -> None:
+    demo = build_interface()
+    demo.queue(concurrency_count=1).launch(server_name=os.environ.get("GRADIO_SERVER_NAME", "0.0.0.0"))
+
+
+if __name__ == "__main__":
+    main()

--- a/hf_space/packages.txt
+++ b/hf_space/packages.txt
@@ -1,0 +1,14 @@
+build-essential
+cmake
+git
+wget
+ninja-build
+libboost-all-dev
+libeigen3-dev
+libfreeimage-dev
+libmetis-dev
+libgoogle-glog-dev
+libgflags-dev
+libglew-dev
+qtbase5-dev
+mesa-utils

--- a/hf_space/requirements.txt
+++ b/hf_space/requirements.txt
@@ -1,0 +1,16 @@
+gradio>=4.31.0
+numpy>=1.24
+opencv-python-headless>=4.8
+scipy>=1.11
+torch>=2.1
+torchvision>=0.16
+tqdm>=4.66
+pyyaml>=6.0
+rich>=13.7
+nerfstudio>=0.3.4
+open3d>=0.17
+plyfile>=1.0
+trimesh>=4.0
+pandas>=2.1
+matplotlib>=3.8
+Pillow>=10.0


### PR DESCRIPTION
## Summary
- drop the Dockerfile and rework documentation around using the stock Gradio Space runtime with requirements.txt and packages.txt
- highlight the optional gaussian-splatting checkout plus environment variables that control repository and output locations
- adjust the app to default to hf_space/runs and to resolve the gaussian splatting backend via GAUSSIAN_SPLATTING_ROOT

## Testing
- python -m compileall hf_space/app.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f7b8ad0c8320a8ff5bf3dfd50d2b